### PR TITLE
add adtnlibj jar to classpath

### DIFF
--- a/libj/java-examples/build.xml
+++ b/libj/java-examples/build.xml
@@ -6,9 +6,11 @@
 	<!-- set global properties for this build -->
 	<property name="src" location="src"/>
 	<property name="lib.dir" value="lib"/>
+        <property name="adtnlibj.dist" value="../dist"/>
 	
 	<path id="classpath">
 		<fileset dir="${lib.dir}" includes="**/*.jar"/>
+		<fileset dir="${adtnlibj.dist}" includes="*.jar"/>
 	</path>
 	
 	<property name="bin" location="bin"/>


### PR DESCRIPTION
adtnlibj jar seems to be missing in libj/java-examples/build.xml (?)
